### PR TITLE
Specify rosdistro to rosdep update will get packages for EOL distros like galactic

### DIFF
--- a/ros2_docker/Dockerfile
+++ b/ros2_docker/Dockerfile
@@ -8,6 +8,8 @@ ENV ROS_DISTRO=galactic
 ENV GROUP_NAME=ros
 ENV WS_NAME=colcon_ws
 
+RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
+
 RUN echo "Set disable_coredump false" >> /etc/sudo.conf
 RUN apt-get update -q && \
     apt-get upgrade -yq && \

--- a/ros2_docker/ros2-setup.bash
+++ b/ros2_docker/ros2-setup.bash
@@ -7,6 +7,6 @@ python3 -m pip install --no-warn-script-location \
 
 source /opt/ros/${ROS_DISTRO}/setup.bash
 cd ~/$WS_NAME
-rosdep update
+rosdep update --rosdistro $ROS_DISTRO
 rosdep install -yrq --from-paths src --ignore-src --rosdistro $ROS_DISTRO
 colcon build


### PR DESCRIPTION
rosdep was not installing nav2_bringup and other required packages because it skips getting package lists for EOL distros.